### PR TITLE
Reticulate fix

### DIFF
--- a/R/retrieve_metaspace_data.R
+++ b/R/retrieve_metaspace_data.R
@@ -101,6 +101,7 @@ retrieve_metaspace_data <- function(project_id = "2024-02-15_20h37m13s",
     reticulate::py_install('pandas')
   if (!reticulate::py_module_available('numpy'))
     reticulate::py_install('numpy')
+  # import name for `metaspace` is different from the pypi package name
   if (!reticulate::py_module_available('metaspace'))
     reticulate::py_install('metaspace2020')
   


### PR DESCRIPTION
Fix to `py_module_available()` call. `metaspace2020` (https://pypi.org/project/metaspace2020/) is being imported in python via `import metaspace` (not `import `metaspace2020`), i.e. package name during installation and import differ.

@sgosline I am still not entirely sure when the `.onLoad` directive is executed. As far as I can tell, the directive was never triggered for me. That is neither during building and installing the package nor attaching spammR (via `library('spammR')`). Is this something that is needed?