### PR TITLE
add catalog-info.yaml file for forge catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,30 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: spamm-r
+  title: spammR
+  description: The goal of spammR is to provide tools for generic analysis of omics data that is measured in spatial context
+  annotations:
+    # Conditional host-specific annotations rendered to avoid empty-string values that fail catalog validation.
+    github.com/project-slug: pnnl-compbio/spammR
+  links:
+    - title: spammR Repository
+      url: https://github.com/pnnl-compbio/spammR
+    - title: spammR Publication
+      url: https://www.biorxiv.org/content/10.1101/2025.08.26.672472v1
+  tags:
+    - r-package
+    - omics-data
+    - spatial-analysis
+spec:
+  type: library
+  owner: user:default/sara.gosline_pnnl.gov # Sara Gosline project contributor
+  visibility: private # to expose this item in the catalog to others at PNNL, change the visibility to 'public'
+  # system: 
+  lifecycle: production
+
+  # TODO: does spammR depend on another resource or component?
+  # dependsOn:
+
+  # TODO: does another resource depend on spammR? 
+  # dependencyOf:


### PR DESCRIPTION
Add a `catalog-info.yaml` file to root to be ingested in the [Forge Catalog](https://forge.pnnl.gov/catalog). Syncing can take up to an hour for it to populate in the table.

By default, the component will only be visible to the direct owner and Forge admins. If you want this component to be visible to others in the Forge Catalog, please update the visibility field to 'public'

Other attributes can be added/modified as well. Reference to our [user docs](https://forge.pnnl.gov/docs/default/component/forge-user-docs/service-catalog/guidelines/)